### PR TITLE
Do not include credentials in XHR

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -3,7 +3,6 @@ import sanitize from './sanitize';
 
 
 const DEFAULT_REQUEST_CONFIG = {
-    credentials: 'include',
     headers: {
         'Accept': 'application/json'
     }


### PR DESCRIPTION
BigchainDB API doesn't use cookies, we can safely remove credentials from the XHR headers.