### PR TITLE
Ignore lock files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
-build/*
-dist/*
-node_modules/*
+dist
+node_modules

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,3 @@
 build/*
 dist/*
 node_modules/*
-yarn.lock
-package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,7 @@
 
 .env
 
-build/*
-
-node_modules/*
+node_modules
 dist
 yarn.lock
 package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ build/*
 
 node_modules/*
 dist
+yarn.lock
+package-lock.json


### PR DESCRIPTION
Lock files are a good idea for full applications but they're kinda overkill for library-style projects like this one. So ignore the npm5/yarn-generated lock files for now to reduce noise.