### PR TITLE
Fix ed25519/node-gyp builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
 language: node_js
 node_js: node
 
+env:
+  - CXX=g++-4.9
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.9
+
 install: npm install
 
 script:


### PR DESCRIPTION
The `ed25519` module gets rebuild with `node-gyp` on installation, which fails when no C++11 compiler is installed.

So let's do just that with this PR.