### PR TITLE
Switch entry point to bundled Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "Apache-2.0",
   "author": "BigchainDB",
-  "main": "./dist/bundle/bundle.js",
+  "main": "./dist/node/index.js",
   "scripts": {
     "lint": "eslint ./",
     "build": "npm run clean && npm run build:bundle && npm run build:cjs && npm run build:dist",


### PR DESCRIPTION
Closes #23.

So this will just work™ in Node.js:

```js
const driver = require('bigchaindb-driver')
```