### PR TITLE
Fix Content-Type issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ const tx = driver.Transaction.makeCreateTransaction(
 const txSigned = driver.Transaction.signTransaction(tx, alice.privateKey)
 
 // Send the transaction off to BigchainDB
-let conn = new driver.Connection(API_PATH, { 'Content-Type': 'application/json' })
+let conn = new driver.Connection(API_PATH)
 
 conn.postTransaction(txSigned)
     .then(() => conn.getStatus(txSigned.id))
@@ -120,7 +120,7 @@ conn.postTransaction(txSigned)
             const txSigned = BigchainDB.Transaction.signTransaction(tx, alice.privateKey)
 
             // Send the transaction off to BigchainDB
-            let conn = new BigchainDB.Connection(API_PATH, { 'Content-Type': 'application/json' })
+            let conn = new BigchainDB.Connection(API_PATH)
 
             conn.postTransaction(txSigned)
                 .then(() => conn.getStatus(txSigned.id))

--- a/src/connection/index.js
+++ b/src/connection/index.js
@@ -1,10 +1,19 @@
 import request from '../request'
 
 
+const HEADER_BLACKLIST = ['content-type']
+
+
 export default class Connection {
-    constructor(path, headers) {
+    constructor(path, headers = {}) {
         this.path = path
-        this.headers = headers
+        this.headers = Object.assign({}, headers)
+
+        Object.keys(headers).forEach(header => {
+            if (HEADER_BLACKLIST.includes(header.toLowerCase())) {
+                throw new Error(`Header ${header} is reserved and cannot be set.`)
+            }
+        })
     }
 
     getApiUrls(endpoint) {

--- a/src/request.js
+++ b/src/request.js
@@ -24,6 +24,7 @@ export default function request(url, config = {}, onlyJsonResponse = true) {
             'Content-Type': 'application/json'
         })
     }
+
     if (!url) {
         return Promise.reject(new Error('Request was not given a url.'))
     }

--- a/test/integration/test_integration.js
+++ b/test/integration/test_integration.js
@@ -308,3 +308,8 @@ test('Search transaction containing an asset', t => {
         .then(({ id }) => conn.listTransactions(id))
         .then(transactions => t.truthy(transactions.length === 1))
 })
+
+
+test('Content-Type cannot be set', t => {
+    t.throws(() => new Connection(API_PATH, { 'Content-Type': 'application/json' }), Error)
+})


### PR DESCRIPTION
`README.md` was misleading. There is no need to manually add the `Content-Type` header. Anyway, if for whatever reason someone adds `Content-Type`, I've added a line of code to raise an error.