### PR TITLE
Encode public_keys array for threshold conditions

### DIFF
--- a/src/transaction/makeOutput.js
+++ b/src/transaction/makeOutput.js
@@ -13,7 +13,9 @@ export default function makeOutput(condition, amount = '1') {
     const publicKeys = []
     const getPublicKeys = details => {
         if (details.type === 'ed25519-sha-256') {
-            publicKeys.push(details.public_key)
+            if (publicKeys.indexOf(details.public_key) === -1) {
+                publicKeys.push(details.public_key)
+            }
         } else if (details.type === 'threshold-sha-256') {
             details.subfulfillments.map(getPublicKeys)
         }

--- a/src/transaction/makeOutput.js
+++ b/src/transaction/makeOutput.js
@@ -13,7 +13,7 @@ export default function makeOutput(condition, amount = '1') {
     const publicKeys = []
     const getPublicKeys = details => {
         if (details.type === 'ed25519-sha-256') {
-            if (publicKeys.indexOf(details.public_key) === -1) {
+            if (!publicKeys.includes(details.public_key)) {
                 publicKeys.push(details.public_key)
             }
         } else if (details.type === 'threshold-sha-256') {

--- a/src/transaction/makeOutput.js
+++ b/src/transaction/makeOutput.js
@@ -10,10 +10,18 @@ export default function makeOutput(condition, amount = '1') {
     if (typeof amount !== 'string') {
         throw new TypeError('`amount` must be of type string')
     }
+    const publicKeys = []
+    const getPublicKeys = details => {
+        if (details.type === 'ed25519-sha-256') {
+            publicKeys.push(details.public_key)
+        } else if (details.type === 'threshold-sha-256') {
+            details.subfulfillments.map(getPublicKeys)
+        }
+    }
+    getPublicKeys(condition.details)
     return {
-        'amount': amount,
         condition,
-        'public_keys': condition.details.hasOwnProperty('public_key') ?
-            [condition.details.public_key] : [],
+        'amount': amount,
+        'public_keys': publicKeys,
     }
 }

--- a/test/transaction/test_cryptoconditions.js
+++ b/test/transaction/test_cryptoconditions.js
@@ -19,21 +19,29 @@ test('Ed25519 condition encoding', t => {
 
 test('Threshold condition encoding', t => {
     const publicKey = '4zvwRjXUKGfvwnParsHAS3HuSVzV5cA4McphgmoCtajS'
+    const ed25519 = Transaction.makeEd25519Condition(publicKey, false)
     const condition = Transaction.makeThresholdCondition(
-            1, [Transaction.makeEd25519Condition(publicKey, false)])
+            1, [ed25519, ed25519])
     const output = Transaction.makeOutput(condition)
     const target = {
         condition: {
             details: {
                 type: 'threshold-sha-256',
                 threshold: 1,
-                subfulfillments: [{
-                    type: 'ed25519-sha-256',
-                    public_key: publicKey,
-                    signature: null,
-                }]
+                subfulfillments: [
+                    {
+                        type: 'ed25519-sha-256',
+                        public_key: publicKey,
+                        signature: null,
+                    },
+                    {
+                        type: 'ed25519-sha-256',
+                        public_key: publicKey,
+                        signature: null,
+                    }
+                ]
             },
-            uri: 'ni:///sha-256;VBIfZSoBprUQy-LVNAzaZ2q-eyWbrcPKtBg1PuNXIpQ?fpt=threshold-sha-256&cost=132096&subtypes=ed25519-sha-256',
+            uri: 'ni:///sha-256;xTeBhQj7ae5Tym7cp83fwtkesQnhdwNwDEMIYwnf2g0?fpt=threshold-sha-256&cost=133120&subtypes=ed25519-sha-256',
         },
         amount: '1',
         public_keys: [publicKey]

--- a/test/transaction/test_cryptoconditions.js
+++ b/test/transaction/test_cryptoconditions.js
@@ -21,19 +21,24 @@ test('Threshold condition encoding', t => {
     const publicKey = '4zvwRjXUKGfvwnParsHAS3HuSVzV5cA4McphgmoCtajS'
     const condition = Transaction.makeThresholdCondition(
             1, [Transaction.makeEd25519Condition(publicKey, false)])
+    const output = Transaction.makeOutput(condition)
     const target = {
-        details: {
-            type: 'threshold-sha-256',
-            threshold: 1,
-            subfulfillments: [{
-                type: 'ed25519-sha-256',
-                public_key: publicKey,
-                signature: null,
-            }]
+        condition: {
+            details: {
+                type: 'threshold-sha-256',
+                threshold: 1,
+                subfulfillments: [{
+                    type: 'ed25519-sha-256',
+                    public_key: publicKey,
+                    signature: null,
+                }]
+            },
+            uri: 'ni:///sha-256;VBIfZSoBprUQy-LVNAzaZ2q-eyWbrcPKtBg1PuNXIpQ?fpt=threshold-sha-256&cost=132096&subtypes=ed25519-sha-256',
         },
-        uri: 'ni:///sha-256;VBIfZSoBprUQy-LVNAzaZ2q-eyWbrcPKtBg1PuNXIpQ?fpt=threshold-sha-256&cost=132096&subtypes=ed25519-sha-256'
+        amount: '1',
+        public_keys: [publicKey]
     }
-    t.deepEqual(target, condition)
+    t.deepEqual(target, output)
 })
 
 

--- a/test/transaction/test_transaction.js
+++ b/test/transaction/test_transaction.js
@@ -17,6 +17,7 @@ import {
 test('Create valid output with default amount', t => {
     const condition = {
         details: {
+            type: 'ed25519-sha-256',
             public_key: 'abc'
         }
     }
@@ -33,6 +34,7 @@ test('Create valid output with default amount', t => {
 test('Create valid output with custom amount', t => {
     const condition = {
         details: {
+            type: 'ed25519-sha-256',
             public_key: 'abc'
         }
     }


### PR DESCRIPTION
Previously wasn't making `output.public_keys` array for threshold conditions