### PR TITLE
Fix typo in upgrade guide

### DIFF
--- a/docs/upgrade-guides/0.2.0.md
+++ b/docs/upgrade-guides/0.2.0.md
@@ -83,7 +83,7 @@ new Connection(PATH).listTransactions(assetId, operation)
 
 ```js
 // new
-new Connection(PATH).searchAsset(search)
+new Connection(PATH).searchAssets(search)
 ```
 
 A querying interface to text-search all assets in BigchainDB. For more


### PR DESCRIPTION
Via: https://gitter.im/bigchaindb/bigchaindb?at=5951653a11755ab05625ce53