### PR TITLE
Issue 50: remove onlyJsonResponse from connection.js

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -89,9 +89,8 @@ export default class Connection {
      * @public
      * @param publicKey
      * @param spent
-     * @param onlyJsonResponse
      */
-    listOutputs(publicKey, spent, onlyJsonResponse = true) {
+    listOutputs(publicKey, spent) {
         const query = {
             public_key: publicKey
         }
@@ -102,7 +101,7 @@ export default class Connection {
         }
         return this._req(this.getApiUrls('outputs'), {
             query
-        }, onlyJsonResponse)
+        })
     }
 
     /**
@@ -159,7 +158,6 @@ export default class Connection {
 
     /**
      * @public
-     *
      * @param transaction
      */
     postTransaction(transaction) {
@@ -172,7 +170,6 @@ export default class Connection {
 
     /**
      * @public
-     *
      * @param search
      */
     searchAssets(search) {

--- a/src/request.js
+++ b/src/request.js
@@ -30,7 +30,7 @@ export default function request(url, config = {}) {
     }
 
     return baseRequest(apiUrl, requestConfig)
-        .then(res => (res.json()))
+        .then(res => res.json())
         .catch(err => {
             console.error(err)
             throw err

--- a/src/request.js
+++ b/src/request.js
@@ -12,7 +12,7 @@ const DEFAULT_REQUEST_CONFIG = {
  * Small wrapper around js-utility-belt's request that provides url resolving,
  * default settings, and response handling.
  */
-export default function request(url, config = {}, onlyJsonResponse = true) {
+export default function request(url, config = {}) {
     // Load default fetch configuration and remove any falsy query parameters
     const requestConfig = Object.assign({}, DEFAULT_REQUEST_CONFIG, config, {
         query: config.query && sanitize(config.query)
@@ -30,7 +30,7 @@ export default function request(url, config = {}, onlyJsonResponse = true) {
     }
 
     return baseRequest(apiUrl, requestConfig)
-        .then(res => (onlyJsonResponse ? res.json() : { json: res.json(), url: res.url }))
+        .then(res => (res.json()))
         .catch(err => {
             console.error(err)
             throw err


### PR DESCRIPTION
Removed onlyJsonResponse in both connection.js->func:listOutputs and request.js
This is a breaking change because the output is returned differently.

Closes #50 
