### PR TITLE
Issue 31: make baseRequest throw payload messages not simply res

### DIFF
--- a/src/baseRequest.js
+++ b/src/baseRequest.js
@@ -74,7 +74,10 @@ export default function baseRequest(url, { jsonBody, query, urlTemplateSpec, ...
             // If status is not a 2xx (based on Response.ok), assume it's an error
             // See https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch
             if (!(res && res.ok)) {
-                throw res
+                return res.json().then(json => {
+                    const error = new Error(json.message || res.statusText)
+                    return Promise.reject(Object.assign(error, { res }))
+                })
             }
             return res
         })


### PR DESCRIPTION
Find a possible solution at: https://codereview.stackexchange.com/questions/133911/fetch-how-to-deal-with-a-json-payload-in-an-error-response (implemented the last piece of code in this thread). 

I'm not sure about how to test this?

Closes #31 