### PR TITLE
remove yarn from local dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
     "json-stable-stringify": "^1.0.1",
     "query-string": "^5.0.0",
     "sprintf-js": "^1.0.3",
-    "tweetnacl": "^1.0.0",
-    "yarn": "^0.27.5"
+    "tweetnacl": "^1.0.0"
   },
   "keywords": [
     "bigchaindb",


### PR DESCRIPTION
`yarn` is usually installed globally, just like `npm` and we never call the locally installed version anywhere so remove it from dependencies. Makes #91 obsolete