### PR TITLE
#31 Solved throw payload message at baserequest

### DIFF
--- a/src/baseRequest.js
+++ b/src/baseRequest.js
@@ -74,11 +74,12 @@ export default function baseRequest(url, { jsonBody, query, urlTemplateSpec, ...
             // If status is not a 2xx (based on Response.ok), assume it's an error
             // See https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch
             if (!(res && res.ok)) {
-                throw {
-                    message: "HTTP Error: Couldn't reach requested webpage",
-                    status: res.status + " " + res.statusText,
+                let errorObject = {
+                    message: 'HTTP Error: Requested page not reachable',
+                    status: '${res.status} ${res.statusText}',
                     requestURI: res.url
                 }
+                throw errorObject
             }
             return res
         })

--- a/src/baseRequest.js
+++ b/src/baseRequest.js
@@ -74,7 +74,11 @@ export default function baseRequest(url, { jsonBody, query, urlTemplateSpec, ...
             // If status is not a 2xx (based on Response.ok), assume it's an error
             // See https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch
             if (!(res && res.ok)) {
-                throw res
+                throw {
+                    message: "HTTP Error: Couldn't reach requested webpage",
+                    status: res.status + " " + res.statusText,
+                    requestURI: res.url
+                }
             }
             return res
         })

--- a/src/baseRequest.js
+++ b/src/baseRequest.js
@@ -76,7 +76,7 @@ export default function baseRequest(url, { jsonBody, query, urlTemplateSpec, ...
             if (!(res && res.ok)) {
                 const errorObject = {
                     message: 'HTTP Error: Requested page not reachable',
-                    status: (res.status) + ' ' + (res.statusText),
+                    status: `${res.status} ${res.statusText}`,
                     requestURI: res.url
                 }
                 throw errorObject

--- a/src/baseRequest.js
+++ b/src/baseRequest.js
@@ -74,9 +74,9 @@ export default function baseRequest(url, { jsonBody, query, urlTemplateSpec, ...
             // If status is not a 2xx (based on Response.ok), assume it's an error
             // See https://developer.mozilla.org/en-US/docs/Web/API/GlobalFetch/fetch
             if (!(res && res.ok)) {
-                let errorObject = {
+                const errorObject = {
                     message: 'HTTP Error: Requested page not reachable',
-                    status: '${res.status} ${res.statusText}',
+                    status: (res.status) + ' ' + (res.statusText),
                     requestURI: res.url
                 }
                 throw errorObject

--- a/test/connection/test_connection.js
+++ b/test/connection/test_connection.js
@@ -7,18 +7,21 @@ import { Connection } from '../../src'
 const API_PATH = 'http://localhost:9984/api/v1/'
 const conn = new Connection(API_PATH)
 
-test('payload thrown at incorrect API_PATH', t => {
+test('Payload thrown at incorrect API_PATH', t => {
     const path = 'http://localhost:9984/api/wrong/'
     const connection = new Connection(path)
     const target = {
         message: 'HTTP Error: Requested page not reachable',
         status: '404 NOT FOUND',
-        requestURI: 'http://localhost:9984/api/wrong/transactionId'
+        requestURI: 'http://localhost:9984/api/wrong/transactions/transactionId'
     }
-    t.deepEqual(target, connection.getTransaction('transactionId'))
+    connection.getTransaction('transactionId')
+        .catch(error => {
+            t.deepEqual(target, error)
+        })
 })
 
-test('generate API URLS', t => {
+test('Generate API URLS', t => {
     const endpoints = {
         'blocks': 'blocks',
         'blocksDetail': 'blocks/%(blockId)s',

--- a/test/connection/test_connection.js
+++ b/test/connection/test_connection.js
@@ -7,6 +7,16 @@ import { Connection } from '../../src'
 const API_PATH = 'http://localhost:9984/api/v1/'
 const conn = new Connection(API_PATH)
 
+test('payload thrown at incorrect API_PATH', t => {
+    const path = 'http://localhost:9984/api/wrong/'
+    const conn = new Connection(path)
+    const target = {
+        message: 'HTTP Error: Requested page not reachable',
+        status: '404 NOT FOUND',
+        requestURI: 'http://localhost:9984/api/wrong/transactionId'
+    }
+    t.deepEqual(target, conn.getTransaction("transactionId"))
+})
 
 test('generate API URLS', t => {
     const endpoints = {

--- a/test/connection/test_connection.js
+++ b/test/connection/test_connection.js
@@ -9,13 +9,13 @@ const conn = new Connection(API_PATH)
 
 test('payload thrown at incorrect API_PATH', t => {
     const path = 'http://localhost:9984/api/wrong/'
-    const conn = new Connection(path)
+    const connection = new Connection(path)
     const target = {
         message: 'HTTP Error: Requested page not reachable',
         status: '404 NOT FOUND',
         requestURI: 'http://localhost:9984/api/wrong/transactionId'
     }
-    t.deepEqual(target, conn.getTransaction("transactionId"))
+    t.deepEqual(target, connection.getTransaction('transactionId'))
 })
 
 test('generate API URLS', t => {


### PR DESCRIPTION
#31  @TimDaub 

```javascript
if (!(res && res.ok)) {
            throw {
                message: "HTTP Error: Couldn't reach requested webpage",
                status: res.status + " " + res.statusText,
                requestURI: res.url
            }
}
```

Result (for wrong API URL):
```javascript
{ 
   message: 'HTTP Error: Couldn\'t reach requested webpage',
   status: '404 NOT FOUND',
   requestURI: 'https://test.ipdb.io/api/**v11**/transactions?asset_id=e77ab9036f4ae5c276502f02c825a8c03349ee1d8be139a44d0cb6ae7a8852f2&operation=TRANSFER' 
}
```