### PR TITLE
Problem: Test "Valid TRANSFER transaction with multiple Ed25519 inputs..." failing

### DIFF
--- a/test/integration/test_integration.js
+++ b/test/integration/test_integration.js
@@ -145,7 +145,7 @@ test('Valid TRANSFER transaction with multiple Ed25519 inputs from different tra
             )
 
             return conn.postTransactionCommit(transferTxSigned1)
-                .then(conn.postTransactionCommit(transferTxSigned2))
+                .then(() => conn.postTransactionCommit(transferTxSigned2))
                 .then(() => {
                     const transferTxMultipleInputs = Transaction.makeTransferTransaction(
                         [{ tx: transferTxSigned1, output_index: 0 },


### PR DESCRIPTION
Solution: Resolving the promise inside the **then()** solves the issue.

The test is failing sometimes, specially when you change the **asset** or **metadata** object in **constants**. That is happening because you get invalid input as the `conn.postTransactionCommit(transferTxSigned2)` is not completed and the input is not valid.