### PR TITLE
 updated docs about new postTransactionAsync

### DIFF
--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -48,12 +48,13 @@ Older versions
 
 	As part of the changes in the BigchainDB 2.0 server, some endpoints were
 	modified. In order to be consistent with them, the JS driver does not have
-	anymore the `pollStatusAndFetchTransaction()` method as there are three
+	anymore the `pollStatusAndFetchTransaction()` method as there are four
 	different ways of posting a transaction:
 
-	- `async` using the `postTransaction`: the response will return immediately and not wait to see if the transaction is valid.
+	- `async` using the `postTransactionAsync`: the response will return immediately and not wait to see if the transaction is valid.
 	- `sync` using the `postTransactionSync`: the response will return after the transaction is validated.
 	- `commit` using the `postTransactionCommit`: the response will return after the transaction is committed to a block.
+	- `commit` using the `postTransaction` which will act the same as `postTransactionCommit`
 
 	By default in the docs we will use the `postTransactionCommit` as is way of
 	being sure that the transaction is validated and commited to a block, so

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -130,6 +130,12 @@ And sent over to a BigchainDB node:
 
 	conn.postTransactionCommit(txCreateAliceSimpleSigned)
 
+or:
+
+.. code-block:: js
+
+	conn.postTransaction(txCreateAliceSimpleSigned)
+
 Notice the transaction ``id``:
 
 .. code-block:: js


### PR DESCRIPTION
Added fourth way to make a transaction (async) on "readme" and added code example on "usage"